### PR TITLE
readme should link back to criticalcss repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-criticalcss
 
-> Grunt wrapper for criticalcss
+> Grunt wrapper for [criticalcss](https://github.com/filamentgroup/criticalcss)
 
 ## Getting Started
 This plugin requires Grunt `~0.4.2`


### PR DESCRIPTION
so now it do.
