### PR TITLE
Fixes config typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ grunt.initConfig({
 	criticalcss: {
 		custom_options: {
 			options: {
-				url: "localhost:4000,
+				url: "localhost:4000",
 				width: 1200,
 				height: 900,
 				outputfile: "dist/critical.css",


### PR DESCRIPTION
the url option string is now closed.
